### PR TITLE
Criar rota v1 login

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,26 +17,26 @@ services:
       NODE_ENV: development
       SERVER_PORT: 4444
       DB_DATABASE: orion
-      DB_CONNECTION_STRING: mongodb://orion_root:j5m966qp7jiypfda@orion-mongo:27017
-      # DB_CONNECTION_STRING: mysql://orion_root:j5m966qp7jiypfda@orion-mysql:3306
+      # DB_CONNECTION_STRING: mongodb://orion_root:j5m966qp7jiypfda@orion-mongo:27017
+      DB_CONNECTION_STRING: mysql://orion_root:j5m966qp7jiypfda@orion-mysql:3306
     networks:
       - orion-connect
   
-  orion-mongo:
-    container_name: orion-mongo
-    image: mongo
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: orion_root
-      MONGO_INITDB_ROOT_PASSWORD: j5m966qp7jiypfda
-      MONGO_INITDB_DATABASE: orion
-    ports:
-      - 27017:27017
-    volumes:
-      - ~/docker/volumes/OrionApi_MongoDB:/data/db
-    networks:
-      - orion-connect
-    logging:
-      driver: none
+  # orion-mongo:
+  #   container_name: orion-mongo
+  #   image: mongo
+  #   environment:
+  #     MONGO_INITDB_ROOT_USERNAME: orion_root
+  #     MONGO_INITDB_ROOT_PASSWORD: j5m966qp7jiypfda
+  #     MONGO_INITDB_DATABASE: orion
+  #   ports:
+  #     - 27017:27017
+  #   volumes:
+  #     - ~/docker/volumes/OrionApi_MongoDB:/data/db
+  #   networks:
+  #     - orion-connect
+  #   logging:
+  #     driver: none
   
   orion-mysql:
     container_name: orion-mysql

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "body-parser": "^1.20.2",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "express-validator": "^7.0.1",
         "mongodb": "^5.9.0",
         "mysql2": "^3.6.2",
         "reflect-metadata": "^0.1.13",
@@ -971,12 +973,12 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "dependencies": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -984,7 +986,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       },
@@ -1764,6 +1766,55 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express/node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/express/node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2423,6 +2474,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -3141,9 +3197,9 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
@@ -5018,12 +5074,12 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
       "requires": {
         "bytes": "3.1.2",
-        "content-type": "~1.0.4",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
@@ -5031,7 +5087,7 @@
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
         "qs": "6.11.0",
-        "raw-body": "2.5.1",
+        "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
       }
@@ -5572,6 +5628,47 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.20.1",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+          "requires": {
+            "bytes": "3.1.2",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "on-finished": "2.4.1",
+            "qs": "6.11.0",
+            "raw-body": "2.5.1",
+            "type-is": "~1.6.18",
+            "unpipe": "1.0.0"
+          }
+        },
+        "raw-body": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+          "requires": {
+            "bytes": "3.1.2",
+            "http-errors": "2.0.0",
+            "iconv-lite": "0.4.24",
+            "unpipe": "1.0.0"
+          }
+        }
+      }
+    },
+    "express-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
+      "requires": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
       }
     },
     "fast-deep-equal": {
@@ -6040,6 +6137,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -6541,9 +6643,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "requires": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
+    "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-validator": "^7.0.1",
     "mongodb": "^5.9.0",
     "mysql2": "^3.6.2",
     "reflect-metadata": "^0.1.13",

--- a/src/api/v1/loginRoute.ts
+++ b/src/api/v1/loginRoute.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import { body, validationResult } from 'express-validator';
+import bodyParser from 'body-parser';
+
+const router = Router();
+router.use(bodyParser.json());
+
+/**
+ * POST route for user login (authentication).
+ *
+ * @route POST /login
+ * @group Authentication
+
+ * @param {Request} req - HTTP request object.
+ * @param {Response} res - HTTP response object.
+ *
+ * @throws {ValidationError} Errors array from validationResult(req) object
+ *
+ * @example - request data:
+ * POST /login
+ * {
+ *   "email": "user@example.com",
+ *   "password": "SafePassword123!" // Min 8 char.,  1 uppercase, 1 lowercase, 1 number.
+ * }
+ *
+ * Success return:
+ *
+ * @returns {object} JSON object with successful authentication message.
+ * @returns {number} status 200 - Success status.
+ *
+ * Failure return:
+ *
+ * @returns {object} JSON object with validation errors for failed authentication.
+ * @returns {number} status 400 - Bad request status for validations.
+ */
+router.post(
+  '/login',
+  [body('email').isEmail(), body('password').isStrongPassword()],
+  (req, res) => {
+    const errors = validationResult(req);
+
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ error: errors.array() });
+    } else {
+      return res.status(200).json({ message: 'Login efetuado com sucesso' });
+    }
+  }
+);
+
+export default router;

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,11 +2,11 @@ import express from 'express';
 import cors from 'cors';
 import swaggerUI from 'swagger-ui-express';
 import swaggerJSDoc from 'swagger-jsdoc';
-import { MongoDataSource } from './config/database';
+import { MysqlDataSource } from './config/database';
 import { swaggerConfig } from './config/swagger';
 import routes from './routes';
 
-MongoDataSource.initialize()
+MysqlDataSource.initialize()
   .then(() => {
     console.log('Database initialized!');
   })

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,10 @@
 import { Router } from 'express';
 import { HomeController } from './controller/HomeController';
+import loginRoute from './api/v1/loginRoute';
 
 const router = Router();
+
+router.use('/v1', loginRoute);
 
 router.get('/', new HomeController().hello);
 


### PR DESCRIPTION
Nesta PR criei uma rota com o namespace /login.
Esta rota está no arquivo src/api/v1/loginRoute e possui validações para email e password,
nativas no express-validator. 

Instalei o body parser para poder testar as validações no insomnia.

PS.: Nossa intenção, como time, é separar o conteúdo da rota em um controller, o que será feito posteriormente, provavelmente pelo Gabriel.

Mensagem de sucesso:
![image](https://github.com/annecaselato/orion-bootcamp-back-boilerplate/assets/43175373/290da001-ab08-428f-9130-626ddf60a030)


Array de erros da resposta: 
![image](https://github.com/annecaselato/orion-bootcamp-back-boilerplate/assets/43175373/7d4f61e9-ac08-446c-ac94-c91475dbf812)
